### PR TITLE
Fix for Linux users running mongodb via services

### DIFF
--- a/tasks/services.js
+++ b/tasks/services.js
@@ -69,7 +69,7 @@ module.exports = function(grunt) {
    * @return {boolean} yes or no.
    */
   function isRunning(process, cb) {
-    var checkCommand = 'ps x|grep ' + process + '|grep -v grep|awk \'{print $1}\'';
+    var checkCommand = 'ps ax|grep ' + process + '|grep -v grep|awk \'{print $1}\'';
     var execOptions = {};
 
     exec(checkCommand, execOptions, function( err, stdout ) {


### PR DESCRIPTION
MongoDB is started on most Linux distributions with:

$ sudo service mongod start

This causes the process to be owned by the user 'mongodb'.  The ps command you're using is restricted to processes owned by the current user.  So, it doesn't detect mongodb's process and tries to start mongod anyway, which fails.

Adding an 'a' flag will cause it to return processes of other users as well.  That will allow the task to recognize that mongodb is already running at the service level and not mess with it.
