### PR TITLE
Enable users to add custom services

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ All tasks are plain tasks, which means you have to include them in `grunt.regist
 * **stopMongo** Stop Mongodb database.
 * **stopPostgres** Stop Postgres database.
 
+### Custom services
+
+You can add custom services using something like this:
+```js
+grunt.registerTask('startSidekiq', 'Start Sidekiq',
+  grunt.services.startService('Sidekiq', 'sidekiq', 'sidekiq -d -C config/sidekiq.yml -L log/sidekiq.log'));
+
+grunt.registerTask('stopSidekiq', 'Kill Sidekiq',
+  grunt.services.killService('Sidekiq')
+);
 
 ### Sample Setup
 

--- a/tasks/services.js
+++ b/tasks/services.js
@@ -45,18 +45,25 @@ module.exports = function(grunt) {
     };
   }
 
+  function killService(service) {
+    return function () {
+      downService(service, 
+                  "ps -ef | grep "+service.toLowerCase()+" | grep -v grep | awk '{print $2}' | xargs kill -9").apply(this, arguments);
+    };
+  }
+
+  grunt.services = {
+    startService: startService,
+    stopService: downService,
+    killService: killService
+  };
+
   grunt.registerTask('stopRedis', 'Kill reddis',
     downService('Redis', 'redis-cli shutdown'));
   grunt.registerTask('stopMongo', 'Kill mongodb',
     downService('Mongodb', 'mongo admin --eval "db.shutdownServer()"'));
   grunt.registerTask('stopPostgres', 'Kill Postgres',
     downService('Postgres', 'pg_ctl -D /usr/local/var/postgres stop -s -m fast'));
-
-  grunt.registerTask('stopSidekiq', 'Kill Sidekiq',
-    downService('Sidekiq', "ps -ef | grep sidekiq | grep -v grep | awk '{print $2}' | xargs kill -9"));
-  grunt.registerTask('stopNgrok', 'Kill Ngrok',
-    downService('Ngrok', "ps -ef | grep ngrok | grep -v grep | awk '{print $2}' | xargs kill -9"));
-
 
   grunt.registerTask('startRedis', 'Start Redis',
     startService('Redis', 'redis-server', 'redis-server'));
@@ -65,12 +72,6 @@ module.exports = function(grunt) {
   grunt.registerTask('startPostgres', 'Start Postgres',
     startService('Postgres', 'postgres',
     'pg_ctl -o "-h 127.0.0.1" -D /usr/local/var/postgres start'));
-
-  grunt.registerTask('startSidekiq', 'Start Sidekiq',
-    startService('Sidekiq', 'sidekiq', 'sidekiq -d -C config/sidekiq.yml -L log/sidekiq.log'));
-  grunt.registerTask('startNgrok', 'Start Ngrok',
-    startService('Ngrok', 'ngrok', 'ngrok -log=none -config=ngrok.yml start local > /dev/null &'));
-
 
   /**
    * Checks if the define process is running

--- a/tasks/services.js
+++ b/tasks/services.js
@@ -52,6 +52,10 @@ module.exports = function(grunt) {
   grunt.registerTask('stopPostgres', 'Kill Postgres',
     downService('Postgres', 'pg_ctl -D /usr/local/var/postgres stop -s -m fast'));
 
+  grunt.registerTask('stopSidekiq', 'Kill Sidekiq',
+    downService('Sidekiq', "ps -ef | grep sidekiq | grep -v grep | awk '{print $2}' | xargs kill -9"));
+  grunt.registerTask('stopNgrok', 'Kill Ngrok',
+    downService('Ngrok', "ps -ef | grep ngrok | grep -v grep | awk '{print $2}' | xargs kill -9"));
 
 
   grunt.registerTask('startRedis', 'Start Redis',
@@ -61,6 +65,11 @@ module.exports = function(grunt) {
   grunt.registerTask('startPostgres', 'Start Postgres',
     startService('Postgres', 'postgres',
     'pg_ctl -o "-h 127.0.0.1" -D /usr/local/var/postgres start'));
+
+  grunt.registerTask('startSidekiq', 'Start Sidekiq',
+    startService('Sidekiq', 'sidekiq', 'sidekiq -d -C config/sidekiq.yml -L log/sidekiq.log'));
+  grunt.registerTask('startNgrok', 'Start Ngrok',
+    startService('Ngrok', 'ngrok', 'ngrok -log=none -config=ngrok.yml start local > /dev/null &'));
 
 
   /**
@@ -93,7 +102,8 @@ module.exports = function(grunt) {
    *                            on to next operation.
    */
   function shellbg(command, cb) {
-    exec(command, {}, function( err ) {
+    console.log("execing");
+    exec(command, {}, function( err, out ) {
       if ( err ) {
         log.error( err );
         cb();
@@ -101,7 +111,7 @@ module.exports = function(grunt) {
       }
     });
     log.ok(['Command:' + command.yellow + ' run successfully']);
-    cb();
+    cb(); 
   }
 };
 


### PR DESCRIPTION
By adding start/stopService to the grunt object we allow users to define their own
tasks for running more services. Adding a killService function allows killing
services without knowing specifics.
